### PR TITLE
docs: write architecture documentation on how DDD fits in Pallas Today

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,15 @@
 
 ## Introduction
 
-Pallas Today is a social media platform that helps you stay connected with friends and family while building a community
-focused on truth and authenticity.
+Pallas Today is a European social media platform built on the values of privacy, security, and intellectual honesty. It
+is designed to bring people together and support collective pursuit of truth — independent of the commercial and
+political pressures that shape existing platforms.
 
-### Finding Truth Together
+**Vision:** A secure, privacy-respecting social media platform that connects people across Europe and empowers them to
+seek truth together, free from the influence of large commercial platforms.
 
-We harness the wisdom of the crowd to evaluate content reliability. Like Wikipedia uses collective knowledge to create
-trustworthy information, we apply the same principle to social media—when most people agree, we're likely closer to
-truth.
-
-Our AI learns from user posts and engagement patterns to provide real-time feedback on content reliability. Readers see
-indicators showing how the community views a post's trustworthiness. Writers receive guidance encouraging accuracy and
-thoughtful contribution. The more people engage authentically, the better the system becomes at surfacing truth.
-
-This isn't censorship—it's empowerment through context and collective wisdom.
-
-### European Values First
-
-Pallas Today is built on European standards, putting people before profits. Your privacy is paramount—we don't sell your
-data or commodify your attention. Communities matter more than corporate interests. We believe social media should serve
-humanity, not exploit it.
-
-In a landscape dominated by misinformation and data exploitation, Pallas Today offers an alternative: connect
-meaningfully with those who matter while contributing to a collective search for truth.
+**Mission:** To build an open, trustworthy social platform that prioritises user privacy and security, fosters genuine
+connection, and is developed and hosted independently within Europe.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ meaningfully with those who matter while contributing to a collective search for
 
 ## Architecture
 
+The architecture of Pallas Today is documented in [doc/architecture/readme.md](doc/architecture/readme.md).
+
 All architectural decisions for this project are documented as Architecture Decision Records (ADRs).
 
 See [doc/adr/readme.md](doc/adr/readme.md) for the complete list of ADRs.

--- a/doc/adr/0010-domain-logic-belongs-in-domain-layer.md
+++ b/doc/adr/0010-domain-logic-belongs-in-domain-layer.md
@@ -1,0 +1,31 @@
+# 10. Domain Logic Belongs in the Domain Layer
+
+Date: 2026-05-06
+
+## Status
+
+Accepted
+
+## Context
+
+Each microservice in Pallas Today is structured in four layers: API, Application, Domain, and Data. The domain layer is
+the intended home for business rules and domain model behaviour. Without a clear guideline, logic tends to drift into
+the application layer or, worse, into API controllers — making it harder to test, reason about, and reuse.
+
+## Decision
+
+All domain logic must be implemented in the domain layer of the microservice that owns it. Business rules, invariants,
+and domain model behaviour belong there and nowhere else.
+
+Deviation is permitted only when there is a well-founded technical reason — for example, a rule that is inherently
+cross-service and cannot be owned by a single domain model without introducing inappropriate coupling. Any deviation
+must be documented with a clear justification in the code (and, if structural, in an ADR).
+
+## Consequences
+
+- Domain logic is easy to locate, test in isolation, and reason about.
+- The application layer stays thin: it orchestrates calls but does not contain business rules.
+- Developers must actively justify placing logic outside the domain layer, which keeps exceptions visible and
+  intentional.
+- Cross-service rules may require coordination patterns (e.g. a saga or an anti-corruption layer) rather than shared
+  code; this adds some complexity but preserves bounded context isolation.

--- a/doc/adr/readme.md
+++ b/doc/adr/readme.md
@@ -9,3 +9,4 @@
 - [7. No data in log records](0007-no-data-in-log-records.md)
 - [8. Log level usage guidelines](0008-log-level-usage-guidelines.md)
 - [9. Issue and pull request workflow](0009-issue-and-pull-request-workflow.md)
+- [10. Domain Logic Belongs in the Domain Layer](0010-domain-logic-belongs-in-domain-layer.md)

--- a/doc/architecture/architecture-overview.md
+++ b/doc/architecture/architecture-overview.md
@@ -25,9 +25,9 @@ microservices. This section introduces the overall structure from two complement
 decomposition (vertical slices) and the internal layering within each component (horizontal slices).
 
 A key architectural principle follows directly from this structure: **all domain logic resides in the backend**. The
-Pallas Today App contains no business rules; it is solely responsible for presenting information and translating user
+Pallas App contains no business rules; it is solely responsible for presenting information and translating user
 interactions into API calls. This keeps the domain model coherent and backend-authoritative, regardless of which client
-or platform accesses it.
+or platform accesses it. See [ADR-0010](../adr/0010-domain-logic-belongs-in-domain-layer.md).
 
 ### Services and Components
 
@@ -83,7 +83,8 @@ hand-written application logic.
 | Data        | Manages interaction with persistent storage.          |
 
 The API layer, like the proxy layer in the app, is a technical addition that keeps transport concerns separate from the
-domain model.
+domain model. The rule that domain logic belongs in the domain layer is recorded in
+[ADR-0010](../adr/0010-domain-logic-belongs-in-domain-layer.md).
 
 ```mermaid
 graph TD
@@ -109,7 +110,8 @@ domain model and its language are self-contained and consistent; concepts are no
 Components communicate through a **shared kernel**: the OpenAPI specifications stored in `api-specs/`. These
 specifications define the contract between contexts — the data structures and operations that cross a boundary. Keeping
 the shared kernel minimal and explicitly versioned prevents tight coupling between services while still enabling
-structured collaboration.
+structured collaboration. The decision to centralise OpenAPI specs is recorded in
+[ADR-0006](../adr/0006-centralised-openapi-spec-storage.md).
 
 This means:
 

--- a/doc/architecture/architecture-overview.md
+++ b/doc/architecture/architecture-overview.md
@@ -4,7 +4,7 @@
 
 Pallas Today is a European social media platform built on the values of privacy, security, and intellectual honesty. It
 is designed to bring people together and support collective pursuit of truth — independent of the commercial and
-political pressures that shape existing platforms.
+political pressures that shape existing platforms. The domain vision concept is described in [1].
 
 ## Vision
 
@@ -38,7 +38,7 @@ The system is composed of the following main building blocks:
 - **Ingress** — acts as an API gateway, routing client requests to the appropriate backend service.
 
 Functionality is distributed across microservices along vertical slices: each service owns a distinct piece of domain
-behaviour end-to-end.
+behaviour end-to-end [3].
 
 ```mermaid
 graph TD
@@ -60,7 +60,7 @@ graph TD
 ### Layering Within Components
 
 While the system is decomposed into microservices, each component still follows a layered internal structure inspired by
-Domain-Driven Design.
+Domain-Driven Design [1, 4].
 
 **Pallas App** is organised in three layers:
 
@@ -104,8 +104,9 @@ graph TD
 
 ### Bounded Contexts
 
-Each component — the Pallas App and every microservice — defines its own bounded context. Within a bounded context, the
-domain model and its language are self-contained and consistent; concepts are not shared across context boundaries.
+Each component — the Pallas App and every microservice — defines its own bounded context [1, 2]. Within a bounded
+context, the domain model and its language are self-contained and consistent; concepts are not shared across context
+boundaries.
 
 Components communicate through a **shared kernel**: the OpenAPI specifications stored in `api-specs/`. These
 specifications define the contract between contexts — the data structures and operations that cross a boundary. Keeping
@@ -119,3 +120,12 @@ This means:
 - The OpenAPI spec for a service is the single authoritative definition of what it exposes to the outside world.
 - The Pallas App consumes these contracts via generated proxy code, ensuring client and server always agree on the
   interface without sharing implementation.
+
+______________________________________________________________________
+
+## Bibliography
+
+- [1] Eric Evans, *Domain-Driven Design: Tackling Complexity in the Heart of Software*, Addison-Wesley, 2003.
+- [2] DDD Crew, *Context Mapping*, <https://github.com/ddd-crew/context-mapping>
+- [3] Baeldung, *Vertical Slice Architecture in Java*, <https://www.baeldung.com/java-vertical-slice-architecture>
+- [4] DDD Practitioners, *Layered Architecture*, <https://ddd-practitioners.com/home/glossary/layered-architecture/>

--- a/doc/architecture/architecture-overview.md
+++ b/doc/architecture/architecture-overview.md
@@ -1,0 +1,119 @@
+# Introduction
+
+## Domain Vision
+
+Pallas Today is a European social media platform built on the values of privacy, security, and intellectual honesty. It
+is designed to bring people together and support collective pursuit of truth — independent of the commercial and
+political pressures that shape existing platforms.
+
+## Vision
+
+A secure, privacy-respecting social media platform that connects people across Europe and empowers them to seek truth
+together, free from the influence of large commercial platforms.
+
+## Mission
+
+To build an open, trustworthy social platform that prioritises user privacy and security, fosters genuine connection,
+and is developed and hosted independently within Europe.
+
+______________________________________________________________________
+
+## System Structure
+
+Pallas Today consists of a cross-platform mobile and desktop application backed by a set of independently deployable
+microservices. This section introduces the overall structure from two complementary perspectives: the service
+decomposition (vertical slices) and the internal layering within each component (horizontal slices).
+
+A key architectural principle follows directly from this structure: **all domain logic resides in the backend**. The
+Pallas Today App contains no business rules; it is solely responsible for presenting information and translating user
+interactions into API calls. This keeps the domain model coherent and backend-authoritative, regardless of which client
+or platform accesses it.
+
+### Services and Components
+
+The system is composed of the following main building blocks:
+
+- **Pallas App** — the cross-platform frontend, targeting mobile and desktop platforms.
+- **Backend services** — a collection of microservices, each responsible for a specific functional domain.
+- **Ingress** — acts as an API gateway, routing client requests to the appropriate backend service.
+
+Functionality is distributed across microservices along vertical slices: each service owns a distinct piece of domain
+behaviour end-to-end.
+
+```mermaid
+graph TD
+    App[Pallas App]
+
+    subgraph Backend
+        Ingress[Ingress / API Gateway]
+        S1[Story Service]
+        S2[... Service]
+        SN[... Service]
+    end
+
+    App --> Ingress
+    Ingress --> S1
+    Ingress --> S2
+    Ingress --> SN
+```
+
+### Layering Within Components
+
+While the system is decomposed into microservices, each component still follows a layered internal structure inspired by
+Domain-Driven Design.
+
+**Pallas App** is organised in three layers:
+
+| Layer        | Responsibility                                                       |
+| ------------ | -------------------------------------------------------------------- |
+| Presentation | Implements the user interface.                                       |
+| Application  | Translates UI interactions into calls to the backend.                |
+| Proxy        | Generated HTTP client code, derived from the OpenAPI specifications. |
+
+The proxy layer is a technical addition outside the DDD model; it keeps generated code clearly separated from
+hand-written application logic.
+
+**Each microservice** is organised in four layers:
+
+| Layer       | Responsibility                                        |
+| ----------- | ----------------------------------------------------- |
+| API         | Implements the HTTP endpoints exposed to clients.     |
+| Application | Orchestrates use cases; may call other microservices. |
+| Domain      | Contains the business logic and domain model.         |
+| Data        | Manages interaction with persistent storage.          |
+
+The API layer, like the proxy layer in the app, is a technical addition that keeps transport concerns separate from the
+domain model.
+
+```mermaid
+graph TD
+    subgraph Pallas App
+        Presentation --> Application_App[Application]
+        Application_App --> Proxy
+    end
+
+    subgraph Microservice
+        API --> Application_Svc[Application]
+        Application_Svc --> Domain
+        Domain --> Data
+    end
+
+    Proxy -->|HTTP| API
+```
+
+### Bounded Contexts
+
+Each component — the Pallas App and every microservice — defines its own bounded context. Within a bounded context, the
+domain model and its language are self-contained and consistent; concepts are not shared across context boundaries.
+
+Components communicate through a **shared kernel**: the OpenAPI specifications stored in `api-specs/`. These
+specifications define the contract between contexts — the data structures and operations that cross a boundary. Keeping
+the shared kernel minimal and explicitly versioned prevents tight coupling between services while still enabling
+structured collaboration.
+
+This means:
+
+- A microservice owns its domain model entirely; no other component reaches into it directly.
+- The OpenAPI spec for a service is the single authoritative definition of what it exposes to the outside world.
+- The Pallas App consumes these contracts via generated proxy code, ensuring client and server always agree on the
+  interface without sharing implementation.

--- a/doc/architecture/readme.md
+++ b/doc/architecture/readme.md
@@ -1,0 +1,7 @@
+# Architecture Documentation
+
+This folder contains the architecture documentation for the Pallas Today platform.
+
+## Chapters
+
+1. [Introduction](architecture-overview.md) — Domain vision, system structure, layering, and bounded contexts.


### PR DESCRIPTION
## Related issue

Closes #6

## Original scope

### In scope

- Describe how DDD maps onto the existing project structure in `pallas_server/`
- Explain the bounded contexts and how they relate to the microservices

### Out of scope

- Documenting individual domain models (tracked per concept, e.g. Story in #32, member network in #35)
- Refactoring existing code to better align with DDD
- Changes to `pallas_app` (Flutter frontend)

## Scope changes

The documentation covers the full system (Pallas Today App + backend microservices) rather than `pallas_server/` in
isolation. This was necessary to give meaningful context for how DDD concepts — layering, bounded contexts, and the
shared kernel — apply across the system boundary. The backend structure is fully documented; no individual domain
models are included.

The `README.md` introduction was also aligned with the domain vision statement introduced in the architecture
documentation. This was not in the original scope but is a natural companion change with negligible risk.

## Testing

- `lefthook run pre-commit` — all hooks passed (markdown lint and formatter both clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with refocused Introduction emphasizing privacy, security, and independence.
  * Added comprehensive architecture documentation covering system structure, layering, and bounded contexts with accompanying diagrams.
  * Introduced Architecture Documentation directory with indexed chapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->