### PR TITLE
Define the member network domain model

### DIFF
--- a/api-specs/community-service/openapi.yaml
+++ b/api-specs/community-service/openapi.yaml
@@ -216,13 +216,11 @@ components:
         The relationship type between two parties:
         trusted (in each other's trusted circle),
         connected (in each other's connected circle),
-        community (Pallas members with no direct circle),
-        guest (not a Pallas member).
+        community (Pallas members with no direct circle).
       enum:
         - trusted
         - connected
         - community
-        - guest
     SuggestionDecision:
       type: string
       description: The decision made in response to a connection suggestion

--- a/api-specs/community-service/openapi.yaml
+++ b/api-specs/community-service/openapi.yaml
@@ -305,11 +305,13 @@ components:
       properties:
         trustedCircle:
           type: array
+          maxItems: 1000
           description: Members in the authenticated member's trusted circle
           items:
             $ref: '#/components/schemas/MemberReference'
         connectedCircle:
           type: array
+          maxItems: 1000
           description: Members in the authenticated member's connected circle
           items:
             $ref: '#/components/schemas/MemberReference'

--- a/api-specs/community-service/openapi.yaml
+++ b/api-specs/community-service/openapi.yaml
@@ -1,0 +1,346 @@
+---
+openapi: 3.0.3
+info:
+  title: CommunityService API
+  description: API for managing member relationships within the Pallas Community
+  version: 0.0.1-SNAPSHOT
+  contact:
+    name: Pallas Team
+servers:
+  - url: http://localhost:8081
+    description: Local development server
+security:
+  - oauth2: []
+paths:
+  /connection-suggestions:
+    post:
+      summary: Create a connection suggestion
+      description: >-
+        Suggest strengthening the bond with another member. The target must accept before the relationship changes.
+      operationId: createConnectionSuggestion
+      tags:
+        - connection-suggestions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConnectionSuggestionInput'
+      responses:
+        '201':
+          description: Connection suggestion created successfully
+          headers:
+            Location:
+              description: URI of the created connection suggestion
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectionSuggestion'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: A pending suggestion between these members already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    get:
+      summary: List incoming connection suggestions
+      description: Retrieve all pending connection suggestions received by the authenticated member.
+      operationId: listConnectionSuggestions
+      tags:
+        - connection-suggestions
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  suggestions:
+                    type: array
+                    maxItems: 100
+                    items:
+                      $ref: '#/components/schemas/ConnectionSuggestion'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /connection-suggestions/{id}/response:
+    put:
+      summary: Respond to a connection suggestion
+      description: >-
+        Accept or reject a connection suggestion. Only the recipient may respond. Accepting updates the relationship.
+      operationId: respondToConnectionSuggestion
+      tags:
+        - connection-suggestions
+      parameters:
+        - name: id
+          in: path
+          description: Connection suggestion ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConnectionSuggestionResponse'
+      responses:
+        '200':
+          description: Response recorded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectionSuggestion'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: The authenticated member is not the recipient of this suggestion
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Connection suggestion not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Suggestion has already been responded to
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /me/circles:
+    get:
+      summary: Retrieve my circles
+      description: >-
+        Retrieve all members of both the trusted and connected circles. Both lists are always returned together.
+      operationId: getMyCircles
+      tags:
+        - circles
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Circles'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /members/{memberId}/relationship:
+    get:
+      summary: Get the relationship with a member
+      description: Returns the relationship type between the authenticated member and the specified member.
+      operationId: getRelationship
+      tags:
+        - relationships
+      parameters:
+        - name: memberId
+          in: path
+          description: The user ID of the other member
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Relationship'
+        '404':
+          description: Member not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  securitySchemes:
+    oauth2:
+      type: oauth2
+      flows:
+        password:
+          tokenUrl: http://localhost:8180/realms/pallas/protocol/openid-connect/token
+          scopes: {}
+  schemas:
+    CircleType:
+      type: string
+      description: The target circle for a connection suggestion
+      enum:
+        - trusted
+        - connected
+    RelationshipType:
+      type: string
+      description: |
+        The relationship type between two parties:
+        trusted (in each other's trusted circle),
+        connected (in each other's connected circle),
+        community (Pallas members with no direct circle),
+        guest (not a Pallas member).
+      enum:
+        - trusted
+        - connected
+        - community
+        - guest
+    SuggestionDecision:
+      type: string
+      description: The decision made in response to a connection suggestion
+      enum:
+        - accepted
+        - rejected
+    ConnectionSuggestionInput:
+      type: object
+      required:
+        - targetMemberId
+        - targetCircle
+      properties:
+        targetMemberId:
+          type: string
+          format: uuid
+          description: The user ID of the member to whom the suggestion is sent
+          example: 123e4567-e89b-12d3-a456-426614174000
+        targetCircle:
+          $ref: '#/components/schemas/CircleType'
+    ConnectionSuggestion:
+      type: object
+      required:
+        - id
+        - initiatorId
+        - targetMemberId
+        - targetCircle
+        - status
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the connection suggestion
+          example: 123e4567-e89b-12d3-a456-426614174000
+        initiatorId:
+          type: string
+          format: uuid
+          description: The user ID of the member who initiated the suggestion
+          example: 123e4567-e89b-12d3-a456-426614174001
+        targetMemberId:
+          type: string
+          format: uuid
+          description: The user ID of the member who received the suggestion
+          example: 123e4567-e89b-12d3-a456-426614174002
+        targetCircle:
+          $ref: '#/components/schemas/CircleType'
+        status:
+          type: string
+          description: Current status of the suggestion
+          enum:
+            - pending
+            - accepted
+            - rejected
+        createdAt:
+          type: string
+          format: date-time
+          description: When the suggestion was created
+        respondedAt:
+          type: string
+          format: date-time
+          description: When the suggestion was responded to, if applicable
+    ConnectionSuggestionResponse:
+      type: object
+      required:
+        - decision
+      properties:
+        decision:
+          $ref: '#/components/schemas/SuggestionDecision'
+    MemberReference:
+      type: object
+      required:
+        - userId
+      properties:
+        userId:
+          type: string
+          format: uuid
+          description: Opaque user identifier (OIDC sub claim)
+          example: 123e4567-e89b-12d3-a456-426614174000
+    Circles:
+      type: object
+      required:
+        - trustedCircle
+        - connectedCircle
+      properties:
+        trustedCircle:
+          type: array
+          description: Members in the authenticated member's trusted circle
+          items:
+            $ref: '#/components/schemas/MemberReference'
+        connectedCircle:
+          type: array
+          description: Members in the authenticated member's connected circle
+          items:
+            $ref: '#/components/schemas/MemberReference'
+    Relationship:
+      type: object
+      required:
+        - memberId
+        - relationshipType
+      properties:
+        memberId:
+          type: string
+          format: uuid
+          description: The user ID of the other member
+          example: 123e4567-e89b-12d3-a456-426614174000
+        relationshipType:
+          $ref: '#/components/schemas/RelationshipType'
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Error message
+        code:
+          type: string
+          description: Error code
+        details:
+          type: string
+          description: Additional error details

--- a/api-specs/community-service/openapi.yaml
+++ b/api-specs/community-service/openapi.yaml
@@ -171,11 +171,11 @@ paths:
       parameters:
         - name: memberId
           in: path
-          description: The user ID of the other member
+          description: Opaque OIDC sub claim identifying the other member (up to 255 ASCII characters)
           required: true
           schema:
             type: string
-            format: uuid
+            maxLength: 255
       responses:
         '200':
           description: Successful response
@@ -237,9 +237,8 @@ components:
       properties:
         targetMemberId:
           type: string
-          format: uuid
-          description: The user ID of the member to whom the suggestion is sent
-          example: 123e4567-e89b-12d3-a456-426614174000
+          maxLength: 255
+          description: Opaque OIDC sub claim of the member to whom the suggestion is sent
         targetCircle:
           $ref: '#/components/schemas/CircleType'
     ConnectionSuggestion:
@@ -259,14 +258,12 @@ components:
           example: 123e4567-e89b-12d3-a456-426614174000
         initiatorId:
           type: string
-          format: uuid
-          description: The user ID of the member who initiated the suggestion
-          example: 123e4567-e89b-12d3-a456-426614174001
+          maxLength: 255
+          description: Opaque OIDC sub claim of the member who initiated the suggestion
         targetMemberId:
           type: string
-          format: uuid
-          description: The user ID of the member who received the suggestion
-          example: 123e4567-e89b-12d3-a456-426614174002
+          maxLength: 255
+          description: Opaque OIDC sub claim of the member who received the suggestion
         targetCircle:
           $ref: '#/components/schemas/CircleType'
         status:
@@ -298,9 +295,8 @@ components:
       properties:
         userId:
           type: string
-          format: uuid
-          description: Opaque user identifier (OIDC sub claim)
-          example: 123e4567-e89b-12d3-a456-426614174000
+          maxLength: 255
+          description: Opaque OIDC sub claim identifying the member (up to 255 ASCII characters)
     Circles:
       type: object
       required:
@@ -325,9 +321,8 @@ components:
       properties:
         memberId:
           type: string
-          format: uuid
-          description: The user ID of the other member
-          example: 123e4567-e89b-12d3-a456-426614174000
+          maxLength: 255
+          description: Opaque OIDC sub claim identifying the other member (up to 255 ASCII characters)
         relationshipType:
           $ref: '#/components/schemas/RelationshipType'
     Error:

--- a/doc/architecture/core-models.md
+++ b/doc/architecture/core-models.md
@@ -1,0 +1,60 @@
+# Core Models
+
+This chapter describes the core domain models of Pallas Today. These models are central to the platform and are
+referenced across all services.
+
+______________________________________________________________________
+
+## Member
+
+A **member** is a registered participant of Pallas Today.
+
+- Needs further refinement.
+
+______________________________________________________________________
+
+## Member Network
+
+Every member belongs to the **Pallas Community**: the complete set of all registered members. Within this community,
+members can discover one another, but access to content and profile information is limited by the relationship between
+them.
+
+Each member maintains two personal circles of relationships:
+
+- **Trusted circle** — the set of members a member considers close. This represents a strong, intimate connection.
+- **Connected circle** — the set of members a member is connected with, but at a lower level of intimacy.
+
+Relationships in both circles are **bidirectional**: if member A includes member B in their trusted circle, then member
+B also has member A in their trusted circle. Neither circle can exist asymmetrically.
+
+These two circles, combined with the broader community and the absence of any relationship, define four distinct
+relationship types that the platform recognises between any two parties:
+
+| Relationship          | Description                                                            |
+| --------------------- | ---------------------------------------------------------------------- |
+| **Trusted members**   | Members within each other's trusted circle.                            |
+| **Connected members** | Members within each other's connected circle.                          |
+| **Community members** | Members of the Pallas Community who share no direct circle membership. |
+| **Guests**            | People who are not a member of the Pallas Community at all.            |
+
+The relationship type between two parties determines what content and profile data each can access, forming the
+foundation of the platform's privacy model.
+
+```mermaid
+---
+config:
+  class:
+    hideEmptyMembersBox: true
+---
+classDiagram
+    class PallasCommunity
+    class Member
+    class TrustedCircle
+    class ConnectedCircle
+
+    PallasCommunity "1" o-- "0..*" Member : contains
+    Member "1" --> "1" TrustedCircle : maintains
+    Member "1" --> "1" ConnectedCircle : maintains
+    TrustedCircle "0..*" --> "0..*" Member : trusted members (bidirectional)
+    ConnectedCircle "0..*" --> "0..*" Member : connected members (bidirectional)
+```

--- a/doc/architecture/core-models.md
+++ b/doc/architecture/core-models.md
@@ -63,7 +63,7 @@ classDiagram
 
 Changing the relationship between two members follows different flows depending on the direction of the change:
 
-- **Upgrading a connection** (moving to a closer circle): the initiating member sends a **connection suggestion** to the
+- **Strengthening the bond** (moving to a closer circle): the initiating member sends a **connection suggestion** to the
   other member. The receiving member must explicitly accept or reject it. The relationship only changes upon acceptance.
-- **Downgrading a connection** (moving to a more distant circle or removing it): the change is applied immediately and
+- **Easing the relationship** (moving to a more distant circle or removing it): the change is applied immediately and
   without requiring consent from the other member.

--- a/doc/architecture/core-models.md
+++ b/doc/architecture/core-models.md
@@ -5,14 +5,6 @@ referenced across all services.
 
 ______________________________________________________________________
 
-## Member
-
-A **member** is a registered participant of Pallas Today.
-
-- Needs further refinement.
-
-______________________________________________________________________
-
 ## Member Network
 
 Every member belongs to the **Pallas Community**: the complete set of all registered members. Within this community,
@@ -59,7 +51,7 @@ classDiagram
     ConnectedCircle "0..*" --> "0..*" Member : connected members (bidirectional)
 ```
 
-### Relation modification
+### Relationship modification
 
 Changing the relationship between two members follows different flows depending on the direction of the change:
 

--- a/doc/architecture/core-models.md
+++ b/doc/architecture/core-models.md
@@ -58,3 +58,12 @@ classDiagram
     TrustedCircle "0..*" --> "0..*" Member : trusted members (bidirectional)
     ConnectedCircle "0..*" --> "0..*" Member : connected members (bidirectional)
 ```
+
+### Relation modification
+
+Changing the relationship between two members follows different flows depending on the direction of the change:
+
+- **Upgrading a connection** (moving to a closer circle): the initiating member sends a **connection suggestion** to the
+  other member. The receiving member must explicitly accept or reject it. The relationship only changes upon acceptance.
+- **Downgrading a connection** (moving to a more distant circle or removing it): the change is applied immediately and
+  without requiring consent from the other member.

--- a/doc/architecture/readme.md
+++ b/doc/architecture/readme.md
@@ -7,3 +7,4 @@ This folder contains the architecture documentation for the Pallas Today platfor
 1. [Ubiquitous Language](ubiquitous-language.md) — Glossary of domain terms used consistently across the codebase and
    documentation.
 1. [Introduction](architecture-overview.md) — Domain vision, system structure, layering, and bounded contexts.
+1. [Core Models](core-models.md) — Core domain models including the member network, circles, and relationship types.

--- a/doc/architecture/ubiquitous-language.md
+++ b/doc/architecture/ubiquitous-language.md
@@ -58,3 +58,19 @@ have the most limited mutual access.
 ### Guests
 
 People who are not members of the Pallas Community. They have the least access to platform content and features.
+
+### Connection suggestion
+
+A request sent by one member to another to upgrade their relationship to a closer circle. The receiving member must
+explicitly accept or reject it. A connection suggestion is only created when moving to a closer relationship;
+downgrading a connection requires no suggestion and no consent.
+
+### Strengthening the bond
+
+The act of moving a relationship with another member to a closer circle. Requires the other member's consent via a
+connection suggestion.
+
+### Easing the relationship
+
+The act of moving a relationship with another member to a more distant circle, or removing it entirely. Applied
+immediately without requiring consent from the other member.

--- a/doc/architecture/ubiquitous-language.md
+++ b/doc/architecture/ubiquitous-language.md
@@ -18,3 +18,43 @@ The textual body of a story, authored by a user.
 ### Publish a story
 
 The action a user takes to create a new story and make it available on the platform.
+
+______________________________________________________________________
+
+## Member network
+
+### Member
+
+A registered participant of Pallas Today. The primary identity within the domain. Identified across all services by an
+opaque `userId` (the OIDC `sub` claim). Detailed profile data is owned by the User Service.
+
+### Pallas Community
+
+The complete set of all members on the platform. Every member belongs to the Pallas Community. Members within the
+community can discover one another, but access is limited by relationship type.
+
+### Trusted circle
+
+A member's set of close, intimate connections. Membership is bidirectional: if A is in B's trusted circle, B is in A's
+trusted circle.
+
+### Connected circle
+
+A member's set of connections at a lower level of intimacy than the trusted circle. Membership is bidirectional.
+
+### Trusted members
+
+Two members who are in each other's trusted circle. Represents the strongest relationship type on the platform.
+
+### Connected members
+
+Two members who are in each other's connected circle.
+
+### Community members
+
+Members of the Pallas Community who share no direct circle membership with each other. They can discover one another but
+have the most limited mutual access.
+
+### Guests
+
+People who are not members of the Pallas Community. They have the least access to platform content and features.

--- a/pallas_app/lib/proxy/client/api_client.dart
+++ b/pallas_app/lib/proxy/client/api_client.dart
@@ -1,4 +1,4 @@
-// Openapi Generator last run: : 2026-05-12T23:42:14.121217
+// Openapi Generator last run: : 2026-05-12T23:46:03.769442
 import 'package:openapi_generator_annotations/openapi_generator_annotations.dart';
 
 @Openapi(

--- a/pallas_app/lib/proxy/client/api_client.dart
+++ b/pallas_app/lib/proxy/client/api_client.dart
@@ -1,4 +1,4 @@
-// Openapi Generator last run: : 2026-05-04T23:04:08.570016
+// Openapi Generator last run: : 2026-05-12T23:33:22.471419
 import 'package:openapi_generator_annotations/openapi_generator_annotations.dart';
 
 @Openapi(

--- a/pallas_app/lib/proxy/client/api_client.dart
+++ b/pallas_app/lib/proxy/client/api_client.dart
@@ -1,4 +1,4 @@
-// Openapi Generator last run: : 2026-05-12T23:33:22.471419
+// Openapi Generator last run: : 2026-05-12T23:34:31.089544
 import 'package:openapi_generator_annotations/openapi_generator_annotations.dart';
 
 @Openapi(

--- a/pallas_app/lib/proxy/client/api_client.dart
+++ b/pallas_app/lib/proxy/client/api_client.dart
@@ -1,4 +1,4 @@
-// Openapi Generator last run: : 2026-05-12T23:34:31.089544
+// Openapi Generator last run: : 2026-05-12T23:41:10.568913
 import 'package:openapi_generator_annotations/openapi_generator_annotations.dart';
 
 @Openapi(

--- a/pallas_app/lib/proxy/client/api_client.dart
+++ b/pallas_app/lib/proxy/client/api_client.dart
@@ -1,4 +1,4 @@
-// Openapi Generator last run: : 2026-05-12T23:41:10.568913
+// Openapi Generator last run: : 2026-05-12T23:42:14.121217
 import 'package:openapi_generator_annotations/openapi_generator_annotations.dart';
 
 @Openapi(

--- a/tool/lefthook/yamlfmt-config.yml
+++ b/tool/lefthook/yamlfmt-config.yml
@@ -3,3 +3,5 @@ formatter:
   type: basic
   max_line_length: 120
   include_document_start: true
+  retain_line_breaks: true
+  scan_folded_as_literal: true


### PR DESCRIPTION
## Related issue

Closes #35

## Original scope

### In scope

- Update `api-specs/` OpenAPI specification(s) to describe the member network data model
- Update `doc/architecture/ubiquitous-language.md` with member network domain terms
- Add a new "Core models" chapter to the architecture documentation in `doc/architecture/`

### Out of scope

- Implementing the domain model in `pallas_server/` (backend code)
- Implementing the domain model in `pallas_app/` (Flutter frontend)
- Database schema or persistence changes
- API endpoint implementation

## Scope changes

The `tool/lefthook/yamlfmt-config.yml` was updated with `retain_line_breaks: true` and `scan_folded_as_literal: true`. This was required to prevent the YAML formatter from collapsing multi-line descriptions in the new OpenAPI spec into lines exceeding the 120-character linter limit. This is a pure tooling fix with no security implications.

The `pallas_app/lib/proxy/client/api_client.dart` change is an auto-generated timestamp update produced by the Dart codegen hook and carries no semantic change.

## Testing

- All `lefthook run pre-commit` hooks passed: Markdown formatter/lint, YAML formatter/lint, Dart formatter/lint, Dart client codegen, and codegen guard.
- YAML linter verified no lines exceed 120 characters in the new OpenAPI spec after formatter runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection suggestions: create, list, and respond to suggestions
  * Member circles and relationship management (trusted and connected levels)
  * Query relationship status between members (API secured via OAuth2)

* **Documentation**
  * New architecture chapter describing core member-relationship/privacy model
  * Expanded ubiquitous language glossary with member-networking terminology

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jurrien-de-klerk/pallas_today/pull/60)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->