### PR TITLE
Revisit log level definitions in ADR-0008 and apply to both services

### DIFF
--- a/doc/adr/0008-log-level-usage-guidelines.md
+++ b/doc/adr/0008-log-level-usage-guidelines.md
@@ -4,7 +4,7 @@ Date: 2026-04-28
 
 ## Status
 
-Accepted
+Superseded by [14. Log level usage guidelines v2](0014-log-level-usage-guidelines-v2.md)
 
 ## Context
 

--- a/doc/adr/0014-log-level-usage-guidelines-v2.md
+++ b/doc/adr/0014-log-level-usage-guidelines-v2.md
@@ -1,0 +1,33 @@
+# 14. Log level usage guidelines v2
+
+Date: 2026-05-20
+
+## Status
+
+Accepted
+
+Supersedes [8. Log level usage guidelines](0008-log-level-usage-guidelines.md)
+
+## Context
+
+[ADR 8](0008-log-level-usage-guidelines.md) defined Error as a crash-only level, leaving non-fatal malfunctions (e.g. a
+downstream service unavailable) without a backtrace in the log, making them harder to diagnose.
+
+A Fatal level is introduced and Error is redefined to cover non-fatal malfunctions, both with a backtrace.
+
+## Decision
+
+- **Fatal**: application crashes and cannot continue. Backtrace written. Example: unhandled top-level exception.
+- **Error**: malfunction that does not crash the application but must be investigated. Backtrace written. Example: a
+  required downstream service is unavailable.
+- **Warning**: suspicious situation the application recovered from automatically. No backtrace. Example: a retry was
+  needed or a fallback value was used.
+- **Info**: notable event in normal flow. Example: incoming request, background job completed.
+- **Debug**: internal execution detail useful when diagnosing a problem.
+
+The trace level is not used.
+
+## Consequences
+
+Fatal and Error events include a backtrace, making it easy to pinpoint root causes. Warning remains noise-free. Code
+reviews must verify the correct level is used, especially distinguishing Error from Warning.

--- a/doc/adr/readme.md
+++ b/doc/adr/readme.md
@@ -13,3 +13,4 @@
 - [11. Secure by Design](0011-secure-by-design.md)
 - [12. Security Risk Analysis in Issues and Pull Requests](0012-security-risk-analysis-in-issues-and-pull-requests.md)
 - [13. App Domain Layer for Data Aggregation](0013-app-domain-layer-for-data-aggregation.md)
+- [14. Log level usage guidelines v2](0014-log-level-usage-guidelines-v2.md)

--- a/pallas_app/lib/application/story_service.dart
+++ b/pallas_app/lib/application/story_service.dart
@@ -55,7 +55,7 @@ class StoryService {
       );
       return false;
     } catch (e, st) {
-      _log.fatal('publishStory unexpected error', e, st);
+      _log.error('publishStory unexpected error', e, st);
       _log.backtrace();
       return false;
     }

--- a/pallas_app/packages/pallas_logger/lib/src/pallas_level.dart
+++ b/pallas_app/packages/pallas_logger/lib/src/pallas_level.dart
@@ -13,7 +13,10 @@ enum PallasLevel {
   /// Unexpected but recoverable events — maps to [Level.WARNING].
   warn,
 
-  /// Critical, unrecoverable failures — maps to [Level.SEVERE].
+  /// Non-fatal malfunction that must be investigated — maps to [Level.SEVERE].
+  error,
+
+  /// Critical, unrecoverable failure that crashes the application — maps to [Level.SHOUT].
   fatal;
 
   /// The corresponding [Level] from the `logging` package.
@@ -21,6 +24,7 @@ enum PallasLevel {
     PallasLevel.debug => Level.FINE,
     PallasLevel.info => Level.INFO,
     PallasLevel.warn => Level.WARNING,
-    PallasLevel.fatal => Level.SEVERE,
+    PallasLevel.error => Level.SEVERE,
+    PallasLevel.fatal => Level.SHOUT,
   };
 }

--- a/pallas_app/packages/pallas_logger/lib/src/pallas_logger.dart
+++ b/pallas_app/packages/pallas_logger/lib/src/pallas_logger.dart
@@ -132,11 +132,17 @@ class PallasLogger {
   void warn(Object? message, [Object? error, StackTrace? stackTrace]) =>
       _log(Level.WARNING, message, error, stackTrace);
 
-  /// Logs a fatal error (maps to [Level.SEVERE]).
+  /// Logs an error (maps to [Level.SEVERE]).
+  ///
+  /// Use for critical failures from which the application cannot recover.
+  void error(Object? message, [Object? error, StackTrace? stackTrace]) =>
+      _log(Level.SEVERE, message, error, stackTrace);
+
+  /// Logs a fatal error (maps to [Level.SHOUT]).
   ///
   /// Use for critical failures from which the application cannot recover.
   void fatal(Object? message, [Object? error, StackTrace? stackTrace]) =>
-      _log(Level.SEVERE, message, error, stackTrace);
+      _log(Level.SHOUT, message, error, stackTrace);
 
   /// Replays all records currently in [PallasLogBuffer] at their original
   /// levels without modifying the buffer.

--- a/pallas_app/packages/pallas_logger/test/pallas_level_test.dart
+++ b/pallas_app/packages/pallas_logger/test/pallas_level_test.dart
@@ -16,13 +16,17 @@ void main() {
       expect(PallasLevel.warn.loggingLevel, equals(Level.WARNING));
     });
 
-    test('fatal maps to Level.SEVERE', () {
-      expect(PallasLevel.fatal.loggingLevel, equals(Level.SEVERE));
+    test('error maps to Level.SEVERE', () {
+      expect(PallasLevel.error.loggingLevel, equals(Level.SEVERE));
     });
 
-    test('all four levels are distinct', () {
+    test('fatal maps to Level.SHOUT', () {
+      expect(PallasLevel.fatal.loggingLevel, equals(Level.SHOUT));
+    });
+
+    test('all five levels are distinct', () {
       final levels = PallasLevel.values.map((l) => l.loggingLevel).toSet();
-      expect(levels, hasLength(4));
+      expect(levels, hasLength(5));
     });
   });
 }

--- a/pallas_app/packages/pallas_logger/test/pallas_logger_test.dart
+++ b/pallas_app/packages/pallas_logger/test/pallas_logger_test.dart
@@ -39,9 +39,14 @@ void main() {
       expect(emitted.first.level, equals(Level.WARNING));
     });
 
-    test('fatal emits Level.SEVERE', () {
-      log.fatal('f message');
+    test('error emits Level.SEVERE', () {
+      log.error('e message');
       expect(emitted.first.level, equals(Level.SEVERE));
+    });
+
+    test('fatal emits Level.SHOUT', () {
+      log.fatal('f message');
+      expect(emitted.first.level, equals(Level.SHOUT));
     });
 
     test('error and stackTrace are forwarded', () {
@@ -58,9 +63,10 @@ void main() {
       log.debug('a');
       log.info('b');
       log.warn('c');
-      log.fatal('d');
+      log.error('d');
+      log.fatal('e');
 
-      expect(PallasLogBuffer.instance.length, equals(4));
+      expect(PallasLogBuffer.instance.length, equals(5));
     });
 
     test('buffer record preserves logger name', () {

--- a/pallas_server/MemberService/src/main/java/com/pallas/memberservice/application/KeycloakIdentityProfileAdapter.java
+++ b/pallas_server/MemberService/src/main/java/com/pallas/memberservice/application/KeycloakIdentityProfileAdapter.java
@@ -36,7 +36,7 @@ public class KeycloakIdentityProfileAdapter implements IdentityProfilePort {
       // Throw a dedicated exception so the handler can log at error level with a backtrace
       // (ADR-0014). Do not return Optional.empty() — that would trigger a misleading warn.
       throw new IdentityProviderException(
-          "Keycloak user not found for subject present in member mapping");
+          "Keycloak user not found for subject present in member mapping", e);
     }
   }
 }

--- a/pallas_server/MemberService/src/main/java/com/pallas/memberservice/application/KeycloakIdentityProfileAdapter.java
+++ b/pallas_server/MemberService/src/main/java/com/pallas/memberservice/application/KeycloakIdentityProfileAdapter.java
@@ -4,6 +4,7 @@ import com.pallas.memberservice.domain.IdentityProfile;
 import com.pallas.memberservice.domain.IdentityProfilePort;
 import jakarta.ws.rs.NotFoundException;
 import java.util.Optional;
+import lombok.CustomLog;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
  * Keycloak adapter for {@link IdentityProfilePort}. Fetches profile data from the Keycloak Admin
  * REST API using the subject claim (which equals the Keycloak user UUID).
  */
+@CustomLog
 @Component
 public class KeycloakIdentityProfileAdapter implements IdentityProfilePort {
 
@@ -31,6 +33,11 @@ public class KeycloakIdentityProfileAdapter implements IdentityProfilePort {
       UserRepresentation user = keycloak.realm(realm).users().get(keycloakSub).toRepresentation();
       return Optional.of(new IdentityProfile(user.getFirstName(), user.getLastName()));
     } catch (NotFoundException e) {
+      // A subject that exists in our mapping table has no corresponding user in Keycloak.
+      // This is a data consistency failure, not a normal 404 — log at error so a backtrace
+      // is written to aid diagnosis (ADR-0014).
+      log.error("Keycloak user not found for subject present in member mapping");
+      log.backtrace();
       return Optional.empty();
     }
   }

--- a/pallas_server/MemberService/src/main/java/com/pallas/memberservice/application/KeycloakIdentityProfileAdapter.java
+++ b/pallas_server/MemberService/src/main/java/com/pallas/memberservice/application/KeycloakIdentityProfileAdapter.java
@@ -2,9 +2,9 @@ package com.pallas.memberservice.application;
 
 import com.pallas.memberservice.domain.IdentityProfile;
 import com.pallas.memberservice.domain.IdentityProfilePort;
+import com.pallas.memberservice.domain.IdentityProviderException;
 import jakarta.ws.rs.NotFoundException;
 import java.util.Optional;
-import lombok.CustomLog;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
  * Keycloak adapter for {@link IdentityProfilePort}. Fetches profile data from the Keycloak Admin
  * REST API using the subject claim (which equals the Keycloak user UUID).
  */
-@CustomLog
 @Component
 public class KeycloakIdentityProfileAdapter implements IdentityProfilePort {
 
@@ -34,11 +33,10 @@ public class KeycloakIdentityProfileAdapter implements IdentityProfilePort {
       return Optional.of(new IdentityProfile(user.getFirstName(), user.getLastName()));
     } catch (NotFoundException e) {
       // A subject that exists in our mapping table has no corresponding user in Keycloak.
-      // This is a data consistency failure, not a normal 404 — log at error so a backtrace
-      // is written to aid diagnosis (ADR-0014).
-      log.error("Keycloak user not found for subject present in member mapping");
-      log.backtrace();
-      return Optional.empty();
+      // Throw a dedicated exception so the handler can log at error level with a backtrace
+      // (ADR-0014). Do not return Optional.empty() — that would trigger a misleading warn.
+      throw new IdentityProviderException(
+          "Keycloak user not found for subject present in member mapping");
     }
   }
 }

--- a/pallas_server/MemberService/src/main/java/com/pallas/memberservice/domain/IdentityProviderException.java
+++ b/pallas_server/MemberService/src/main/java/com/pallas/memberservice/domain/IdentityProviderException.java
@@ -7,7 +7,7 @@ package com.pallas.memberservice.domain;
  */
 public class IdentityProviderException extends RuntimeException {
 
-  public IdentityProviderException(String message) {
-    super(message);
+  public IdentityProviderException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/pallas_server/MemberService/src/main/java/com/pallas/memberservice/domain/IdentityProviderException.java
+++ b/pallas_server/MemberService/src/main/java/com/pallas/memberservice/domain/IdentityProviderException.java
@@ -1,0 +1,13 @@
+package com.pallas.memberservice.domain;
+
+/**
+ * Thrown when the identity provider returns an unexpected response that indicates a data
+ * consistency failure. This is distinct from {@link MemberNotFoundException}, which signals a
+ * normal not-found outcome. This exception triggers error-level logging with a backtrace.
+ */
+public class IdentityProviderException extends RuntimeException {
+
+  public IdentityProviderException(String message) {
+    super(message);
+  }
+}

--- a/pallas_server/MemberService/src/main/java/com/pallas/memberservice/exception/GlobalExceptionHandler.java
+++ b/pallas_server/MemberService/src/main/java/com/pallas/memberservice/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.pallas.memberservice.exception;
 
+import com.pallas.memberservice.domain.IdentityProviderException;
 import com.pallas.memberservice.domain.MemberNotFoundException;
 import com.pallas.memberservice.model.Error;
 import lombok.CustomLog;
@@ -47,6 +48,18 @@ public class GlobalExceptionHandler {
     error.setMessage("Missing required parameter: " + ex.getParameterName());
     error.setCode(HttpStatus.BAD_REQUEST.toString());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+  }
+
+  @ExceptionHandler(IdentityProviderException.class)
+  public ResponseEntity<Error> handleIdentityProviderException(IdentityProviderException ex) {
+    // The identity provider returned an unexpected response indicating a data consistency failure.
+    // Log at error with a backtrace to aid diagnosis (ADR-0014).
+    log.error("Identity provider failure: {}", ex.getMessage());
+    log.backtrace();
+    Error error = new Error();
+    error.setMessage("Internal server error");
+    error.setCode(HttpStatus.INTERNAL_SERVER_ERROR.toString());
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
   }
 
   @ExceptionHandler(MemberNotFoundException.class)


### PR DESCRIPTION
## Related issue

Closes #80

## Original scope

### In scope

- Review and update `doc/adr/0008-log-level-usage-guidelines.md`
- Regenerate `doc/adr/readme.md` table of contents
- Align all `log.warn` and `log.error` calls in `StoryService/src/` and `MemberService/src/` with the updated ADR
- Fix the generic exception handler in both services to attach the exception object so the stack trace is included

### Out of scope

-

## Scope changes

The following changes fall outside the declared in-scope items:

- **`pallas_app/lib/application/story_service.dart`** — `publishStory` catch block reclassified from `fatal` to `error`: the app does not crash, making it a non-fatal malfunction under ADR-0014.
- **`KeycloakIdentityProfileAdapter`** — Keycloak returning 404 for a subject that exists in our own mapping table is a data consistency malfunction, not an expected outcome. Reclassified to `error` + `backtrace()`.
- **`pallas-logger` infrastructure** — prerequisite work (new `PallasLogger`, revised `PallasBacktrace`, `BacktraceBuffer`, `@CustomLog`) that enabled `log.backtrace()` and moved the backtrace call into the logger itself.
- **`pallas_app/packages/pallas_logger/`** — Dart logger aligned with the same backtrace approach.
- **`.github/copilot-instructions.md` and `pallas_server/lombok.config`** — tooling/config updates.

Note on the stack-trace in-scope item: the issue asked to attach the exception object to `log.error()`. The implementation instead uses `log.backtrace()` (ring-buffer replay). This satisfies the same diagnostic goal while respecting ADR-0007 (no identity data in log records), since passing `ex` directly could leak identity data from the exception message.

## Testing

- `mvn test -pl MemberService -am` — 18 tests, 0 failures
- `lefthook run pre-commit` — all hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated logging guidelines documentation with refined severity classifications for improved error tracking and debugging practices.
  * Added new logging standards to the architectural decision records index.

* **New Features**
  * Introduced dedicated error logging method for non-crashing system faults requiring investigation and diagnostics.
  * Enhanced logging system with improved severity level differentiation across all application services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jurrien-de-klerk/pallas_today/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->