### PR TITLE
Fix CommunityService integration leftovers

### DIFF
--- a/doc/adr/0016-disable-pmd-guardlogstatement-rule.md
+++ b/doc/adr/0016-disable-pmd-guardlogstatement-rule.md
@@ -1,0 +1,27 @@
+# 16. Disable PMD GuardLogStatement rule
+
+Date: 2026-06-09
+
+## Status
+
+Accepted
+
+## Context
+
+The PMD rule `GuardLogStatement` flags log statements that evaluate a value without an `isXxxEnabled()` guard. The
+rule's intent is valid: it avoids evaluating expensive expressions for log records that are discarded anyway.
+
+However, the situation needs more nuance. Guarding a log statement also prevents it from entering the log-backtrace
+buffer, which is undesirable: backtraces must contain the full picture of what happened before a Fatal or Error event
+(see [ADR 14](0014-log-level-usage-guidelines-v2.md)).
+
+## Decision
+
+The PMD rule `GuardLogStatement` is disabled in all PMD rulesets. Instead, developers are responsible for ensuring that
+no expensive function calls are evaluated inside log statements.
+
+## Consequences
+
+Log statements always reach the log-backtrace buffer, keeping backtraces complete. No guard boilerplate is needed around
+log calls. The risk of accidentally evaluating expensive expressions in log statements is no longer caught by static
+analysis; code reviews must watch for expensive calls in log statements.

--- a/doc/adr/readme.md
+++ b/doc/adr/readme.md
@@ -15,3 +15,4 @@
 - [13. App Domain Layer for Data Aggregation](0013-app-domain-layer-for-data-aggregation.md)
 - [14. Log level usage guidelines v2](0014-log-level-usage-guidelines-v2.md)
 - [15. Service-prefixed URL path segments](0015-service-prefixed-url-path-segments.md)
+- [16. Disable PMD GuardLogStatement rule](0016-disable-pmd-guardlogstatement-rule.md)

--- a/pallas_server/CommunityService/pmd-ruleset.xml
+++ b/pallas_server/CommunityService/pmd-ruleset.xml
@@ -2,7 +2,10 @@
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Custom ruleset for Community Service" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
   <description>Community Service PMD rules with generated code exclusions.</description>
   <!-- Use default rule sets but exclude generated code -->
-  <rule ref="category/java/bestpractices.xml"/>
+  <rule ref="category/java/bestpractices.xml">
+    <!-- Exclude GuardLogStatement: guards keep log records out of the log-backtrace buffer (see ADR 16) -->
+    <exclude name="GuardLogStatement"/>
+  </rule>
   <rule ref="category/java/design.xml">
     <!-- Exclude SignatureDeclareThrowsException: Spring Security filter chains require Exception declaration -->
     <exclude name="SignatureDeclareThrowsException"/>

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/api/ConnectionSuggestionsController.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/api/ConnectionSuggestionsController.java
@@ -39,7 +39,7 @@ public class ConnectionSuggestionsController implements ConnectionSuggestionsApi
   public ResponseEntity<ListConnectionSuggestions200Response> listConnectionSuggestions() {
     log.info("GET /communities/connection-suggestions");
     List<com.pallas.communityservice.model.ConnectionSuggestion> models =
-        applicationService.listIncomingSuggestions().stream().map(this::toModel).toList();
+        applicationService.listPendingSuggestions().stream().map(this::toModel).toList();
     ListConnectionSuggestions200Response response = new ListConnectionSuggestions200Response();
     response.setSuggestions(models);
     return ResponseEntity.ok(response);

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/application/CommunityApplicationService.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/application/CommunityApplicationService.java
@@ -55,14 +55,15 @@ public class CommunityApplicationService {
   }
 
   /**
-   * List all incoming pending connection suggestions for the authenticated member.
+   * List all pending connection suggestions involving the authenticated member (as initiator or
+   * target).
    *
-   * @return pending suggestions received by the current member
+   * @return pending suggestions visible to the current member
    */
-  public List<ConnectionSuggestion> listIncomingSuggestions() {
+  public List<ConnectionSuggestion> listPendingSuggestions() {
     UUID currentUuid = getCurrentUserUuid();
-    log.info("listIncomingSuggestions");
-    return communityDomainService.listIncomingSuggestions(currentUuid);
+    log.info("listPendingSuggestions");
+    return communityDomainService.listPendingSuggestions(currentUuid);
   }
 
   /**

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/ConnectionSuggestionRepository.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/ConnectionSuggestionRepository.java
@@ -3,13 +3,15 @@ package com.pallas.communityservice.data;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface ConnectionSuggestionRepository extends JpaRepository<ConnectionSuggestionEntity, UUID> {
 
-  @org.springframework.data.jpa.repository.Query(
+  @Query(
       "SELECT e FROM ConnectionSuggestionEntity e"
           + " WHERE (e.initiatorId = :memberId OR e.targetId = :memberId)"
           + " AND e.status = :status")
   List<ConnectionSuggestionEntity> findByParticipantAndStatus(
-      UUID memberId, SuggestionStatusEntity status);
+      @Param("memberId") UUID memberId, @Param("status") SuggestionStatusEntity status);
 }

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/ConnectionSuggestionRepository.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/ConnectionSuggestionRepository.java
@@ -6,6 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 interface ConnectionSuggestionRepository extends JpaRepository<ConnectionSuggestionEntity, UUID> {
 
-  List<ConnectionSuggestionEntity> findByTargetIdAndStatus(
-      UUID targetId, SuggestionStatusEntity status);
+  @org.springframework.data.jpa.repository.Query(
+      "SELECT e FROM ConnectionSuggestionEntity e"
+          + " WHERE (e.initiatorId = :memberId OR e.targetId = :memberId)"
+          + " AND e.status = :status")
+  List<ConnectionSuggestionEntity> findByParticipantAndStatus(
+      UUID memberId, SuggestionStatusEntity status);
 }

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/JpaCircleMembershipAdapter.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/JpaCircleMembershipAdapter.java
@@ -7,9 +7,11 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.CustomLog;
 import org.springframework.stereotype.Component;
 
 /** JPA adapter implementing {@link CircleMembershipPort}. */
+@CustomLog
 @Component
 public class JpaCircleMembershipAdapter implements CircleMembershipPort {
 
@@ -21,6 +23,7 @@ public class JpaCircleMembershipAdapter implements CircleMembershipPort {
 
   @Override
   public CircleMembership save(CircleMembership membership) {
+    log.debug("save: upserting circle membership with circle type {}", membership.getCircleType());
     CircleMembershipId id =
         new CircleMembershipId(membership.getMemberIdA(), membership.getMemberIdB());
 
@@ -29,6 +32,7 @@ public class JpaCircleMembershipAdapter implements CircleMembershipPort {
             .findById(id)
             .orElseGet(
                 () -> {
+                  log.debug("save: no existing membership found, creating new entity");
                   CircleMembershipEntity e = new CircleMembershipEntity();
                   e.setId(id);
                   e.setMemberSince(OffsetDateTime.now());
@@ -36,22 +40,30 @@ public class JpaCircleMembershipAdapter implements CircleMembershipPort {
                 });
 
     entity.setCircleType(toEntityCircleType(membership.getCircleType()));
-    return toDomain(repository.save(entity));
+    CircleMembership saved = toDomain(repository.save(entity));
+    log.debug("save: circle membership saved");
+    return saved;
   }
 
   @Override
   public List<CircleMembership> findAllByMemberIdAndCircleType(
       UUID memberId, CircleType circleType) {
-    return repository
-        .findAllByMemberIdAndCircleType(memberId, toEntityCircleType(circleType))
-        .stream()
-        .map(this::toDomain)
-        .toList();
+    log.debug("findAllByMemberIdAndCircleType: querying for circle type {}", circleType);
+    List<CircleMembership> results =
+        repository.findAllByMemberIdAndCircleType(memberId, toEntityCircleType(circleType)).stream()
+            .map(this::toDomain)
+            .toList();
+    log.debug("findAllByMemberIdAndCircleType: found {} membership(s)", results.size());
+    return results;
   }
 
   @Override
   public Optional<CircleMembership> findByPair(UUID memberIdA, UUID memberIdB) {
-    return repository.findByEitherPair(memberIdA, memberIdB).map(this::toDomain);
+    log.debug("findByPair: querying membership");
+    Optional<CircleMembership> result =
+        repository.findByEitherPair(memberIdA, memberIdB).map(this::toDomain);
+    log.debug("findByPair: membership {}", result.isPresent() ? "found" : "not found");
+    return result;
   }
 
   // -------------------------------------------------------------------------

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/JpaConnectionSuggestionAdapter.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/JpaConnectionSuggestionAdapter.java
@@ -47,7 +47,7 @@ public class JpaConnectionSuggestionAdapter implements ConnectionSuggestionPort 
         repository.findByParticipantAndStatus(memberId, SuggestionStatusEntity.PENDING).stream()
             .map(this::toDomain)
             .toList();
-    log.debug("findPendingByParticipantId");
+    log.debug("findPendingByParticipantId: found {} pending suggestion(s)", results.size());
     return results;
   }
 

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/JpaConnectionSuggestionAdapter.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/JpaConnectionSuggestionAdapter.java
@@ -8,9 +8,11 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.CustomLog;
 import org.springframework.stereotype.Component;
 
 /** JPA adapter implementing {@link ConnectionSuggestionPort}. */
+@CustomLog
 @Component
 public class JpaConnectionSuggestionAdapter implements ConnectionSuggestionPort {
 
@@ -22,35 +24,51 @@ public class JpaConnectionSuggestionAdapter implements ConnectionSuggestionPort 
 
   @Override
   public ConnectionSuggestion save(ConnectionSuggestion suggestion) {
+    log.debug("save: persisting new connection suggestion");
     ConnectionSuggestionEntity entity = toEntity(suggestion);
     entity.setCreatedAt(OffsetDateTime.now());
-    return toDomain(repository.save(entity));
+    ConnectionSuggestion saved = toDomain(repository.save(entity));
+    log.debug("save: connection suggestion persisted");
+    return saved;
   }
 
   @Override
   public Optional<ConnectionSuggestion> findById(UUID id) {
-    return repository.findById(id).map(this::toDomain);
+    log.debug("findById: querying connection suggestion");
+    Optional<ConnectionSuggestion> result = repository.findById(id).map(this::toDomain);
+    log.debug("findById: suggestion {}", result.isPresent() ? "found" : "not found");
+    return result;
   }
 
   @Override
-  public List<ConnectionSuggestion> findPendingByTargetId(UUID targetId) {
-    return repository.findByTargetIdAndStatus(targetId, SuggestionStatusEntity.PENDING).stream()
-        .map(this::toDomain)
-        .toList();
+  public List<ConnectionSuggestion> findPendingByParticipantId(UUID memberId) {
+    log.debug("findPendingByParticipantId: querying pending suggestions");
+    List<ConnectionSuggestion> results =
+        repository.findByParticipantAndStatus(memberId, SuggestionStatusEntity.PENDING).stream()
+            .map(this::toDomain)
+            .toList();
+    log.debug("findPendingByParticipantId");
+    return results;
   }
 
   @Override
   public ConnectionSuggestion update(ConnectionSuggestion suggestion) {
+    log.debug("update: loading suggestion for update");
     ConnectionSuggestionEntity entity =
         repository
             .findById(suggestion.getId())
             .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Cannot update non-existent suggestion: " + suggestion.getId()));
+                () -> {
+                  log.debug("update: suggestion not found — illegal state");
+                  return new IllegalStateException(
+                      "Cannot update non-existent suggestion: " + suggestion.getId());
+                });
+    log.debug("update: applying new status {}", suggestion.getStatus());
     entity.setStatus(toEntityStatus(suggestion.getStatus()));
     entity.setRespondedAt(suggestion.getRespondedAt());
-    return toDomain(repository.save(entity));
+    ConnectionSuggestion updated = toDomain(repository.save(entity));
+    log.debug("update: suggestion updated");
+    return updated;
   }
 
   // -------------------------------------------------------------------------

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/MemberServiceHttpAdapter.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/MemberServiceHttpAdapter.java
@@ -32,13 +32,18 @@ public class MemberServiceHttpAdapter implements MemberServicePort {
 
   @Override
   public UUID resolveCurrentMemberId(String bearerToken) {
-    log.debug("resolveCurrentMemberId: calling member service");
+    log.debug(
+        "resolveCurrentMemberId: calling member service at {}/members/me", apiClient.getBasePath());
     try {
       apiClient.addDefaultHeader(HttpHeaders.AUTHORIZATION, bearerToken);
       var member = membersApi.getAuthenticatedMember();
       log.debug("resolveCurrentMemberId: resolved");
       return member.getMemberId();
     } catch (ApiException e) {
+      log.debug(
+          "resolveCurrentMemberId: Member Service call failed with HTTP {}, body: {}",
+          e.getCode(),
+          e.getResponseBody());
       throw new MemberServiceUnavailableException(
           "Member Service returned error: " + e.getCode(), e);
     }

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/MemberServiceHttpAdapter.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/data/MemberServiceHttpAdapter.java
@@ -40,10 +40,7 @@ public class MemberServiceHttpAdapter implements MemberServicePort {
       log.debug("resolveCurrentMemberId: resolved");
       return member.getMemberId();
     } catch (ApiException e) {
-      log.debug(
-          "resolveCurrentMemberId: Member Service call failed with HTTP {}, body: {}",
-          e.getCode(),
-          e.getResponseBody());
+      log.debug("resolveCurrentMemberId: Member Service call failed with HTTP {}", e.getCode());
       throw new MemberServiceUnavailableException(
           "Member Service returned error: " + e.getCode(), e);
     }

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/CommunityDomainService.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/CommunityDomainService.java
@@ -69,11 +69,11 @@ public class CommunityDomainService {
    * @return pending suggestions visible to this member
    */
   @Transactional(readOnly = true)
-  public List<ConnectionSuggestion> listIncomingSuggestions(UUID currentId) {
-    log.debug("listIncomingSuggestions: fetching for member");
+  public List<ConnectionSuggestion> listPendingSuggestions(UUID currentId) {
+    log.debug("listPendingSuggestions: fetching for member");
     List<ConnectionSuggestion> results =
         connectionSuggestionPort.findPendingByParticipantId(currentId);
-    log.debug("listIncomingSuggestions: found {} pending suggestion(s)", results.size());
+    log.debug("listPendingSuggestions: found {} pending suggestion(s)", results.size());
     return results;
   }
 

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/CommunityDomainService.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/CommunityDomainService.java
@@ -210,6 +210,8 @@ public class CommunityDomainService {
             .circleType(suggestion.getTargetCircle())
             .memberSince(OffsetDateTime.now())
             .build();
+    log.debug("acceptSuggestion: persisting circle membership");
     circleMembershipPort.save(membership);
+    log.debug("acceptSuggestion: circle membership saved");
   }
 }

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/CommunityDomainService.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/CommunityDomainService.java
@@ -40,11 +40,14 @@ public class CommunityDomainService {
       UUID initiatorId, UUID targetId, CircleType targetCircle) {
     log.debug("createConnectionSuggestion: creating suggestion");
     if (initiatorId.equals(targetId)) {
+      log.debug("createConnectionSuggestion: rejected — self-suggestion");
       throw new IllegalArgumentException("A member cannot suggest a connection with themselves");
     }
+    log.debug(
+        "createConnectionSuggestion: self-check passed, building suggestion for circle {}",
+        targetCircle);
     ConnectionSuggestion suggestion =
         ConnectionSuggestion.builder()
-            .id(UUID.randomUUID())
             .initiatorId(initiatorId)
             .targetId(targetId)
             .targetCircle(targetCircle)
@@ -92,17 +95,26 @@ public class CommunityDomainService {
   public ConnectionSuggestion respondToSuggestion(
       UUID suggestionId, UUID currentId, SuggestionDecision decision) {
 
+    log.debug("respondToSuggestion: looking up suggestion");
     ConnectionSuggestion suggestion =
         connectionSuggestionPort
             .findById(suggestionId)
-            .orElseThrow(() -> new ConnectionSuggestionNotFoundException(suggestionId));
+            .orElseThrow(
+                () -> {
+                  log.debug("respondToSuggestion: suggestion not found");
+                  return new ConnectionSuggestionNotFoundException(suggestionId);
+                });
+    log.debug("respondToSuggestion: suggestion found with status {}", suggestion.getStatus());
 
     if (!suggestion.getTargetId().equals(currentId)) {
+      log.debug("respondToSuggestion: rejected — caller is not the recipient");
       throw new NotSuggestionRecipientException(suggestionId);
     }
     if (!suggestion.isPending()) {
+      log.debug("respondToSuggestion: rejected — suggestion already responded");
       throw new SuggestionAlreadyRespondedException(suggestionId);
     }
+    log.debug("respondToSuggestion: guards passed, applying decision {}", decision);
 
     SuggestionStatus newStatus =
         decision == SuggestionDecision.ACCEPTED
@@ -120,11 +132,15 @@ public class CommunityDomainService {
             .respondedAt(OffsetDateTime.now())
             .build();
 
+    log.debug("respondToSuggestion: persisting updated suggestion");
     ConnectionSuggestion saved = connectionSuggestionPort.update(updated);
+    log.debug("respondToSuggestion: suggestion updated");
 
     if (decision == SuggestionDecision.ACCEPTED) {
       log.debug("respondToSuggestion: accepted — creating circle membership");
       acceptSuggestion(suggestion, currentId);
+    } else {
+      log.debug("respondToSuggestion: rejected — no circle membership created");
     }
 
     log.debug("respondToSuggestion: done");
@@ -143,7 +159,11 @@ public class CommunityDomainService {
    */
   @Transactional(readOnly = true)
   public List<CircleMembership> getTrustedCircle(UUID currentId) {
-    return circleMembershipPort.findAllByMemberIdAndCircleType(currentId, CircleType.TRUSTED);
+    log.debug("getTrustedCircle: fetching trusted circle members");
+    List<CircleMembership> results =
+        circleMembershipPort.findAllByMemberIdAndCircleType(currentId, CircleType.TRUSTED);
+    log.debug("getTrustedCircle: found {} member(s)", results.size());
+    return results;
   }
 
   /**
@@ -175,14 +195,18 @@ public class CommunityDomainService {
    */
   @Transactional(readOnly = true)
   public RelationshipType getRelationship(UUID currentId, UUID targetId) {
+    log.debug("getRelationship: looking up circle membership between pair");
     Optional<CircleMembership> membership = circleMembershipPort.findByPair(currentId, targetId);
-    return membership
-        .map(
-            m ->
-                m.getCircleType() == CircleType.TRUSTED
-                    ? RelationshipType.TRUSTED
-                    : RelationshipType.CONNECTED)
-        .orElse(RelationshipType.COMMUNITY);
+    RelationshipType result =
+        membership
+            .map(
+                m ->
+                    m.getCircleType() == CircleType.TRUSTED
+                        ? RelationshipType.TRUSTED
+                        : RelationshipType.CONNECTED)
+            .orElse(RelationshipType.COMMUNITY);
+    log.debug("getRelationship: resolved to {}", result);
+    return result;
   }
 
   // -------------------------------------------------------------------------
@@ -190,12 +214,16 @@ public class CommunityDomainService {
   // -------------------------------------------------------------------------
 
   private void acceptSuggestion(ConnectionSuggestion suggestion, UUID acceptorId) {
+    log.debug(
+        "acceptSuggestion: building circle membership for circle {}", suggestion.getTargetCircle());
     UUID initiatorId = suggestion.getInitiatorId();
 
     // Canonical ordering: member with the smaller UUID is A.
+    // Use string comparison to match PostgreSQL's unsigned UUID ordering;
+    // UUID.compareTo() uses signed long arithmetic and can disagree with the DB.
     UUID memberIdA;
     UUID memberIdB;
-    if (initiatorId.compareTo(acceptorId) < 0) {
+    if (initiatorId.toString().compareTo(acceptorId.toString()) < 0) {
       memberIdA = initiatorId;
       memberIdB = acceptorId;
     } else {

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/CommunityDomainService.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/CommunityDomainService.java
@@ -52,21 +52,26 @@ public class CommunityDomainService {
             .createdAt(OffsetDateTime.now())
             .respondedAt(null)
             .build();
+    log.debug("createConnectionSuggestion: persisting");
     ConnectionSuggestion saved = connectionSuggestionPort.save(suggestion);
     log.debug("createConnectionSuggestion: suggestion saved");
     return saved;
   }
 
   /**
-   * List all pending incoming connection suggestions for the given member.
+   * List all pending connection suggestions that involve the given member, either as the initiator
+   * or as the target.
    *
    * @param currentId Member Service UUID of the authenticated member
-   * @return pending suggestions received by this member
+   * @return pending suggestions visible to this member
    */
   @Transactional(readOnly = true)
   public List<ConnectionSuggestion> listIncomingSuggestions(UUID currentId) {
     log.debug("listIncomingSuggestions: fetching for member");
-    return connectionSuggestionPort.findPendingByTargetId(currentId);
+    List<ConnectionSuggestion> results =
+        connectionSuggestionPort.findPendingByParticipantId(currentId);
+    log.debug("listIncomingSuggestions: found {} pending suggestion(s)", results.size());
+    return results;
   }
 
   /**
@@ -149,7 +154,11 @@ public class CommunityDomainService {
    */
   @Transactional(readOnly = true)
   public List<CircleMembership> getConnectedCircle(UUID currentId) {
-    return circleMembershipPort.findAllByMemberIdAndCircleType(currentId, CircleType.CONNECTED);
+    log.debug("getConnectedCircle: fetching connected circle members");
+    List<CircleMembership> results =
+        circleMembershipPort.findAllByMemberIdAndCircleType(currentId, CircleType.CONNECTED);
+    log.debug("getConnectedCircle: found {} member(s)", results.size());
+    return results;
   }
 
   // -------------------------------------------------------------------------

--- a/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/ConnectionSuggestionPort.java
+++ b/pallas_server/CommunityService/src/main/java/com/pallas/communityservice/domain/ConnectionSuggestionPort.java
@@ -24,12 +24,13 @@ public interface ConnectionSuggestionPort {
   Optional<ConnectionSuggestion> findById(UUID id);
 
   /**
-   * Returns all pending suggestions whose recipient is {@code targetId}.
+   * Returns all pending suggestions in which {@code memberId} participates, either as the initiator
+   * or as the target.
    *
-   * @param targetId the Member Service UUID of the intended recipient
-   * @return incoming pending suggestions
+   * @param memberId the Member Service UUID of the member
+   * @return pending suggestions visible to this member
    */
-  List<ConnectionSuggestion> findPendingByTargetId(UUID targetId);
+  List<ConnectionSuggestion> findPendingByParticipantId(UUID memberId);
 
   /**
    * Update the status and responded-at timestamp of a suggestion.

--- a/pallas_server/CommunityService/src/main/resources/db/migration/V2__convert_native_enums_to_text.sql
+++ b/pallas_server/CommunityService/src/main/resources/db/migration/V2__convert_native_enums_to_text.sql
@@ -1,0 +1,56 @@
+-- Convert PostgreSQL native enum columns to text + CHECK constraints.
+-- Normalize stored enum values to uppercase so JPA can use @Enumerated(EnumType.STRING)
+-- without custom converters.
+
+-- Remove enum-typed dependencies from V1 before altering column types.
+DROP INDEX IF EXISTS uq_pending_suggestion_pending;
+ALTER TABLE connection_suggestions
+ALTER COLUMN status DROP DEFAULT;
+
+-- connection_suggestions.target_circle
+ALTER TABLE connection_suggestions
+ALTER COLUMN target_circle TYPE text USING target_circle::text;
+
+UPDATE connection_suggestions
+SET target_circle = UPPER(target_circle::text)
+WHERE target_circle::text IN ('trusted', 'connected');
+
+ALTER TABLE connection_suggestions
+ADD CONSTRAINT chk_connection_suggestions_target_circle
+CHECK (target_circle IN ('TRUSTED', 'CONNECTED'));
+
+-- connection_suggestions.status
+ALTER TABLE connection_suggestions
+ALTER COLUMN status TYPE text USING status::text;
+
+UPDATE connection_suggestions
+SET status = UPPER(status::text)
+WHERE status::text IN ('pending', 'accepted', 'rejected');
+
+ALTER TABLE connection_suggestions
+ADD CONSTRAINT chk_connection_suggestions_status
+CHECK (status IN ('PENDING', 'ACCEPTED', 'REJECTED'));
+
+ALTER TABLE connection_suggestions
+ALTER COLUMN status SET DEFAULT 'PENDING';
+
+-- circle_membership.circle_type
+ALTER TABLE circle_membership
+ALTER COLUMN circle_type TYPE text USING circle_type::text;
+
+UPDATE circle_membership
+SET circle_type = UPPER(circle_type::text)
+WHERE circle_type::text IN ('trusted', 'connected');
+
+ALTER TABLE circle_membership
+ADD CONSTRAINT chk_circle_membership_circle_type
+CHECK (circle_type IN ('TRUSTED', 'CONNECTED'));
+
+-- Drop now-unused enum types from V1.
+DROP TYPE circle_type;
+DROP TYPE suggestion_status;
+
+-- Recreate the partial unique index with text semantics and uppercase status.
+CREATE UNIQUE INDEX uq_pending_suggestion_pending
+ON connection_suggestions (initiator_id, target_id, target_circle)
+WHERE status = 'PENDING';

--- a/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/api/CirclesControllerTest.java
+++ b/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/api/CirclesControllerTest.java
@@ -127,7 +127,7 @@ class CirclesControllerTest {
       UUID memberId1, UUID memberId2, CircleType circleType) {
     UUID memberIdA;
     UUID memberIdB;
-    if (memberId1.compareTo(memberId2) < 0) {
+    if (memberId1.toString().compareTo(memberId2.toString()) < 0) {
       memberIdA = memberId1;
       memberIdB = memberId2;
     } else {

--- a/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/api/ConnectionSuggestionsControllerTest.java
+++ b/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/api/ConnectionSuggestionsControllerTest.java
@@ -118,7 +118,8 @@ class ConnectionSuggestionsControllerTest {
             .respondedAt(null)
             .build();
 
-    when(suggestionPort.findPendingByTargetId(CURRENT_USER_ID)).thenReturn(List.of(suggestion1));
+    when(suggestionPort.findPendingByParticipantId(CURRENT_USER_ID))
+        .thenReturn(List.of(suggestion1));
 
     mockMvc
         .perform(
@@ -132,7 +133,7 @@ class ConnectionSuggestionsControllerTest {
   @Test
   void listConnectionSuggestions_WithNoSuggestions_Returns200WithEmptyList() throws Exception {
     when(memberServicePort.resolveCurrentMemberId(anyString())).thenReturn(CURRENT_USER_ID);
-    when(suggestionPort.findPendingByTargetId(CURRENT_USER_ID)).thenReturn(List.of());
+    when(suggestionPort.findPendingByParticipantId(CURRENT_USER_ID)).thenReturn(List.of());
 
     mockMvc
         .perform(

--- a/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/api/RelationshipsControllerTest.java
+++ b/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/api/RelationshipsControllerTest.java
@@ -47,10 +47,10 @@ class RelationshipsControllerTest {
     UUID currentMemberId = UUID.fromString("11111111-1111-1111-1111-111111111111");
     UUID targetMemberId = UUID.fromString("22222222-2222-2222-2222-222222222222");
 
-    // Ensure canonical ordering: member with smaller UUID is A
+    // Ensure canonical ordering: member with smaller UUID is A (string/unsigned comparison).
     UUID memberIdA;
     UUID memberIdB;
-    if (currentMemberId.compareTo(targetMemberId) < 0) {
+    if (currentMemberId.toString().compareTo(targetMemberId.toString()) < 0) {
       memberIdA = currentMemberId;
       memberIdB = targetMemberId;
     } else {

--- a/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/domain/CommunityDomainServiceTest.java
+++ b/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/domain/CommunityDomainServiceTest.java
@@ -144,7 +144,7 @@ class CommunityDomainServiceTest {
             .createdAt(pendingSuggestion.getCreatedAt())
             .respondedAt(null)
             .build();
-    when(connectionSuggestionPort.findPendingByTargetId(receiverId))
+    when(connectionSuggestionPort.findPendingByParticipantId(receiverId))
         .thenReturn(List.of(suggestion1, suggestion2));
 
     // When
@@ -152,14 +152,14 @@ class CommunityDomainServiceTest {
 
     // Then
     assertThat(result).hasSize(2).contains(suggestion1, suggestion2);
-    verify(connectionSuggestionPort).findPendingByTargetId(receiverId);
+    verify(connectionSuggestionPort).findPendingByParticipantId(receiverId);
   }
 
   @Test
   void listIncomingSuggestions_WithNoSuggestions_ReturnsEmptyList() {
     // Given
     UUID receiverId = UUID.fromString("44444444-4444-4444-4444-444444444444");
-    when(connectionSuggestionPort.findPendingByTargetId(receiverId)).thenReturn(List.of());
+    when(connectionSuggestionPort.findPendingByParticipantId(receiverId)).thenReturn(List.of());
 
     // When
     List<ConnectionSuggestion> result = service.listIncomingSuggestions(receiverId);

--- a/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/domain/CommunityDomainServiceTest.java
+++ b/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/domain/CommunityDomainServiceTest.java
@@ -117,11 +117,11 @@ class CommunityDomainServiceTest {
   }
 
   // =========================================================================
-  // listIncomingSuggestions tests
+  // listPendingSuggestions tests
   // =========================================================================
 
   @Test
-  void listIncomingSuggestions_WithPendingSuggestions_ReturnsList() {
+  void listPendingSuggestions_WithPendingSuggestions_ReturnsList() {
     // Given
     UUID receiverId = UUID.fromString("44444444-4444-4444-4444-444444444444");
     ConnectionSuggestion suggestion1 =
@@ -148,7 +148,7 @@ class CommunityDomainServiceTest {
         .thenReturn(List.of(suggestion1, suggestion2));
 
     // When
-    List<ConnectionSuggestion> result = service.listIncomingSuggestions(receiverId);
+    List<ConnectionSuggestion> result = service.listPendingSuggestions(receiverId);
 
     // Then
     assertThat(result).hasSize(2).contains(suggestion1, suggestion2);
@@ -156,13 +156,13 @@ class CommunityDomainServiceTest {
   }
 
   @Test
-  void listIncomingSuggestions_WithNoSuggestions_ReturnsEmptyList() {
+  void listPendingSuggestions_WithNoSuggestions_ReturnsEmptyList() {
     // Given
     UUID receiverId = UUID.fromString("44444444-4444-4444-4444-444444444444");
     when(connectionSuggestionPort.findPendingByParticipantId(receiverId)).thenReturn(List.of());
 
     // When
-    List<ConnectionSuggestion> result = service.listIncomingSuggestions(receiverId);
+    List<ConnectionSuggestion> result = service.listPendingSuggestions(receiverId);
 
     // Then
     assertThat(result).isEmpty();

--- a/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/domain/CommunityDomainServiceTest.java
+++ b/pallas_server/CommunityService/src/test/java/com/pallas/communityservice/domain/CommunityDomainServiceTest.java
@@ -467,7 +467,7 @@ class CommunityDomainServiceTest {
     UUID partnerId = UUID.randomUUID();
     UUID memberIdA;
     UUID memberIdB;
-    if (currentId.compareTo(partnerId) < 0) {
+    if (currentId.toString().compareTo(partnerId.toString()) < 0) {
       memberIdA = currentId;
       memberIdB = partnerId;
     } else {

--- a/pallas_server/compose.yaml
+++ b/pallas_server/compose.yaml
@@ -105,6 +105,7 @@ services:
       KEYCLOAK_JWK_SET_URI: http://keycloak:8080/realms/pallas/protocol/openid-connect/certs
       KEYCLOAK_PUBLIC_URL: http://localhost:8180
       KEYCLOAK_REALM: pallas
+      MEMBER_SERVICE_BASE_URL: http://member-service:8081
       SPRING_PROFILES_ACTIVE: dev
       SPRING_DATASOURCE_URL: jdbc:postgresql://community-db:5432/communityservice
       SPRING_DATASOURCE_USERNAME: communityservice

--- a/tool/maven/pmd-ruleset.xml
+++ b/tool/maven/pmd-ruleset.xml
@@ -5,7 +5,7 @@
     <!--
       GuardLogStatement fires on every parameterised log call (e.g. log.warn("…", arg))
       even though Log4j2 / SLF4J already evaluates arguments lazily via {} placeholders.
-      Wrapping every log call in isXxxEnabled() guards would be unnecessary boilerplate.
+      Guards would also keep log records out of the log-backtrace buffer (see ADR 16).
     -->
     <exclude name="GuardLogStatement"/>
   </rule>


### PR DESCRIPTION
## Related issue

Closes #92

## Original scope

### In scope

- Rename `findPendingByTargetId` → `findPendingByParticipantId`; query both initiator and target.
- Replace `UUID.compareTo()` with string comparison for canonical pair ordering (match PostgreSQL).
- Remove pre-generated suggestion ID from `createConnectionSuggestion`.
- Flyway V2 migration: convert native enum columns to `text` + `CHECK` constraints.
- Add missing `MEMBER_SERVICE_BASE_URL` to `community-service` in `compose.yaml`.
- Add debug logging to domain service and data adapters.
- Disable PMD `GuardLogStatement` in the CommunityService ruleset; update `tool/maven/pmd-ruleset.xml` comment.
- ADR 16: document decision to disable `GuardLogStatement`; regenerate ADR TOC.

### Out of scope

- Other microservices, frontend changes, end-to-end tests.

## Scope changes

None. All changes are within the declared in-scope items.

## Testing

- `lefthook run pre-commit` — all hooks passed (including SQL formatter, which auto-fixed indentation in the V2 migration).
- `mvn install` — full build and test suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection suggestion queries now correctly return suggestions where the user is either the initiator or target.

* **Chores**
  * Database migration to improve data consistency.
  * Enhanced diagnostic logging across Community Service components.
  * Docker configuration update for internal service connectivity.
  * Documented architectural decision regarding static analysis configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->